### PR TITLE
fix(link): set tabindex for disabled links

### DIFF
--- a/src/components/elements/link/Link.vue
+++ b/src/components/elements/link/Link.vue
@@ -8,6 +8,7 @@
         target="_self"
         :download="type === 'download'"
         :disabled="disabled"
+        :tabindex="disabled ? '-1' : '0'"
         v-bind="$attrs"
         @click="clickHandler($event)"
         @keydown="keyHandler($event)"


### PR DESCRIPTION
Looks like this behaviour was automatically set when a link was disabled by the bootstrap component