### PR TITLE
fix(lazyhydration): set non-focus event for hydration on non-safari

### DIFF
--- a/src/components/patterns/footer/components/FooterNavList.vue
+++ b/src/components/patterns/footer/components/FooterNavList.vue
@@ -3,7 +3,7 @@
         class="vs-footer-nav-list"
         data-test="vs-footer-nav-list"
     >
-        <LazyHydrate on-interaction>
+        <LazyHydrate :on-interaction="['focus', 'click']">
             <div class="vs-footer-nav-list">
                 <VsAccordion :break-point="breakPoint">
                     <VsRow>

--- a/src/components/patterns/global-menu/GlobalMenu.vue
+++ b/src/components/patterns/global-menu/GlobalMenu.vue
@@ -9,7 +9,7 @@
                     cols="12"
                     class="vs-global-menu__wrapper"
                 >
-                    <LazyHydrate on-interaction>
+                    <LazyHydrate :on-interaction="['focus', 'click']">
                         <!-- Small Screens Menu -->
                         <VsGlobalMenuDropdown
                             class="d-lg-none"

--- a/src/components/patterns/mega-nav/components/MegaNavTopMenuItem.vue
+++ b/src/components/patterns/mega-nav/components/MegaNavTopMenuItem.vue
@@ -4,7 +4,7 @@
         data-test="vs-mega-nav-top-menu-item"
         ref="menuToggle"
     >
-        <LazyHydrate on-interaction>
+        <LazyHydrate :on-interaction="['focus', 'click']">
             <VsMegaNavDropdown
                 menu-toggle-alt-text="Toggle Menu"
             >


### PR DESCRIPTION
On-interaction defaults to only checking for the focus event, which doesn't seem to work properly in Safari. Changing it to focus and click appears to fix it there and make these dropdowns accessible in ssr mode.

![image](https://github.com/visitscotland/vs-design-system/assets/97949877/940e2869-0544-48fe-bebf-3930243c15be)
